### PR TITLE
Cache episodes for offline reading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,6 +46,12 @@ export default function Home() {
         if (response.ok) {
           const data = await response.json();
           setEpisodes(data);
+          // Cache episodes so reading pages can load them offline
+          try {
+            localStorage.setItem("allEpisodes", JSON.stringify(data));
+          } catch (e) {
+            console.error("Failed to cache episodes", e);
+          }
         } else {
           console.error("Failed to fetch episodes");
         }

--- a/app/read/[episode]/page.tsx
+++ b/app/read/[episode]/page.tsx
@@ -27,9 +27,29 @@ export default function EpisodePage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchEpisode = async () => {
+    const loadEpisode = async () => {
       try {
-        const episodeNumber = params.episode;
+        const episodeNumber = Number(params.episode);
+
+        // Try to load from cached episodes first
+        const cached = localStorage.getItem("allEpisodes");
+        if (cached) {
+          try {
+            const allEpisodes: EpisodeAnalysis[] = JSON.parse(cached);
+            const cachedEpisode = allEpisodes.find(
+              (ep) => ep.episode === episodeNumber
+            );
+            if (cachedEpisode) {
+              setEpisode(cachedEpisode);
+              setLoading(false);
+              return;
+            }
+          } catch (e) {
+            console.error("Failed to parse cached episodes", e);
+          }
+        }
+
+        // Fallback to API request
         const response = await fetch(`/api/episode-analysis/${episodeNumber}`);
 
         if (response.ok) {
@@ -47,7 +67,7 @@ export default function EpisodePage() {
     };
 
     if (params.episode) {
-      fetchEpisode();
+      loadEpisode();
     }
   }, [params.episode]);
 


### PR DESCRIPTION
## Summary
- store downloaded episodes in `localStorage`
- load episode data from cache before making API calls

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878775e265c832cb983bf2283d349b8