### PR TITLE
Fix home redirect when returning from episode

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,33 @@ export default function Home() {
     }
   }, []);
 
+  // When landing on the site, automatically open the most recently read episode
+  // but avoid redirecting if coming from an episode page or when explicitly
+  // disabled via the `noRedirect` query parameter.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("noRedirect") === "1") {
+      return;
+    }
+
+    if (document.referrer.includes("/read/")) {
+      return;
+    }
+
+    const savedViewed = localStorage.getItem("viewedEpisodes");
+    if (savedViewed) {
+      try {
+        const viewedArray: number[] = JSON.parse(savedViewed);
+        if (viewedArray.length > 0) {
+          const latest = Math.max(...viewedArray);
+          router.replace(`/read/${latest}?banner=1`);
+        }
+      } catch (e) {
+        console.error("Failed to parse viewed episodes", e);
+      }
+    }
+  }, []);
+
   useEffect(() => {
     const fetchEpisodes = async () => {
       try {

--- a/app/read/[episode]/page.tsx
+++ b/app/read/[episode]/page.tsx
@@ -25,6 +25,7 @@ export default function EpisodePage() {
   const [episode, setEpisode] = useState<EpisodeAnalysis | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showBanner, setShowBanner] = useState(false);
 
   useEffect(() => {
     const loadEpisode = async () => {
@@ -71,6 +72,32 @@ export default function EpisodePage() {
     }
   }, [params.episode]);
 
+  // Mark current and previous episodes as read
+  useEffect(() => {
+    if (episode) {
+      try {
+        const saved = localStorage.getItem("viewedEpisodes");
+        const viewed = saved ? new Set<number>(JSON.parse(saved)) : new Set<number>();
+        for (let i = 1; i <= episode.episode; i++) {
+          viewed.add(i);
+        }
+        localStorage.setItem("viewedEpisodes", JSON.stringify(Array.from(viewed)));
+      } catch (e) {
+        console.error("Failed to update viewed episodes", e);
+      }
+    }
+  }, [episode]);
+
+  // Show banner when redirected to the most recently read episode
+  useEffect(() => {
+    const search = new URLSearchParams(window.location.search);
+    if (search.get("banner") === "1") {
+      setShowBanner(true);
+      const t = setTimeout(() => setShowBanner(false), 3000);
+      return () => clearTimeout(t);
+    }
+  }, []);
+
   if (loading) {
     return (
       <div className="min-h-screen bg-white flex items-center justify-center">
@@ -91,11 +118,17 @@ export default function EpisodePage() {
 
   return (
     <div className="min-h-screen bg-white">
+      {showBanner && (
+        <div className="relative bg-yellow-100 text-yellow-800 py-2 text-center">
+          <span className="font-semibold">Most recently read</span>
+          <div className="absolute left-1/2 -bottom-2 transform -translate-x-1/2 w-0 h-0 border-x-8 border-b-8 border-x-transparent border-b-yellow-100" />
+        </div>
+      )}
       {/* Mobile Navigation */}
       <div className="lg:hidden bg-gray-100 border-b">
         <div className="flex items-center justify-between">
           <button
-            onClick={() => router.push("/")}
+            onClick={() => router.push("/?noRedirect=1")}
             className="flex items-center gap-2 text-gray-600 hover:text-gray-800"
           >
             <svg
@@ -120,7 +153,7 @@ export default function EpisodePage() {
       <div className="hidden lg:block bg-gray-100 border-b">
         <div className="flex items-center justify-between">
           <button
-            onClick={() => router.push("/")}
+            onClick={() => router.push("/?noRedirect=1")}
             className="flex items-center gap-2 text-gray-600 hover:text-gray-800"
           >
             <svg
@@ -258,7 +291,7 @@ export default function EpisodePage() {
               </button>
 
               <button
-                onClick={() => router.push("/")}
+                onClick={() => router.push("/?noRedirect=1")}
                 className="text-gray-600 hover:text-gray-800 px-4 py-2 rounded-lg hover:bg-gray-100 transition-colors"
               >
                 <span className="text-sm lg:text-base">All Episodes</span>


### PR DESCRIPTION
## Summary
- prevent automatic redirect on the home page when coming from an episode
- pass `noRedirect=1` when navigating back to episodes so the reader can return

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879430b0550832cb53c72715ee3032e